### PR TITLE
✨ Added option to return exit code of 1 if no tests found

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/davidahouse/XCResultKit",
         "state": {
           "branch": null,
-          "revision": "57510fda3f8dbfdff0b4b71dfd62dd5050d752f6",
-          "version": "0.5.2"
+          "revision": "b8cc1631ea91c9e8f9166d58ad607f0278f7553e",
+          "version": "0.5.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/davidahouse/XCResultKit",
-        from: "0.5.2")
+        from: "0.5.7")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/xcodebuild-to-md/main.swift
+++ b/Sources/xcodebuild-to-md/main.swift
@@ -29,8 +29,14 @@ let findings = gatherFindings(from: resultKit, path: path)
 // Now see if there are test summaries
 let testSummary = gatherTestSummary(from: resultKit)
 
-if (commandLine.output?.lowercased() == "summary") {
-    summaryOutput(findings: findings, testSummary: testSummary)
+if let output = commandLine.output {
+    if (output.lowercased() == "summary") {
+        summaryOutput(findings: findings, testSummary: testSummary)
+    } else {
+        textOutput(findings: findings, testSummary: testSummary, includeWarnings: commandLine.includeWarnings)
+    }
 } else {
-    textOutput(findings: findings, testSummary: testSummary, includeWarnings: commandLine.includeWarnings)
+    if testSummary.allTests <= 0 {
+        exit(1)
+    }
 }


### PR DESCRIPTION
This PR adds an option to return an exit code of 1 if no tests were found. This can help certain situations in a CI setup where you want to take different paths if no tests are executed at all. Also this PR bumps the XCResultKit dependency to the latest version.

closes #5 