### PR TITLE
✨ added badges mode for generating alt summary

### DIFF
--- a/Sources/xcodebuild-to-md/BadgeOutput.swift
+++ b/Sources/xcodebuild-to-md/BadgeOutput.swift
@@ -1,0 +1,50 @@
+//
+//  File.swift
+//  
+//
+//  Created by David House on 2/20/21.
+//
+
+import Foundation
+
+func badgeOutput(findings: [String: CompileFindings], testSummary: TestSummary) {
+    
+    var warnings = 0
+    var errors = 0
+    
+    for (_, finding) in findings {
+        for finding in finding.findings {
+            switch finding.category {
+            case .error:
+                errors += 1
+            case .warning:
+                warnings += 1
+            }
+        }
+    }
+    
+    if errors > 0 {
+        print("- ![errors](https://img.shields.io/badge/Compile%20Errors-\(errors)-critical)")
+    }
+
+    if warnings > 0 {
+        print("- ![warnings](https://img.shields.io/badge/Compile%20Warnings-\(warnings)-yellow)")
+    }
+    
+    print("- ![totaltests](https://img.shields.io/badge/Unit%20Test%20Count-\(testSummary.allTests)-informational)")
+    print("- ![successtests](https://img.shields.io/badge/Unit%20Test%20Count-\(testSummary.successTests)-success)")
+    print("- ![failedtests](https://img.shields.io/badge/Unit%20Test%20Count-\(testSummary.failedTests)-critical)")
+
+    if let coverage = testSummary.codeCoverage {
+        let totalCoverage = Int(coverage.lineCoverage * 100.0)
+        if totalCoverage <= 50 {
+            print("- ![coverage](https://img.shields.io/badge/Code%20Coverage-\(totalCoverage)%25-critical)")
+        } else if totalCoverage < 70 {
+            print("- ![coverage](https://img.shields.io/badge/Code%20Coverage-\(totalCoverage)%25-yellow)")
+        } else if totalCoverage < 90 {
+            print("- ![coverage](https://img.shields.io/badge/Code%20Coverage-\(totalCoverage)%25-yellowgreen)")
+        } else {
+            print("- ![coverage](https://img.shields.io/badge/Code%20Coverage-\(totalCoverage)%25-success)")
+        }
+    }
+}

--- a/Sources/xcodebuild-to-md/CommandLine.swift
+++ b/Sources/xcodebuild-to-md/CommandLine.swift
@@ -64,7 +64,7 @@ struct CommandLineArguments {
 
     func printInstructions() {
         var instructions = "Usage: xcodebuild-to-md -derivedDataFolder <path>"
-        instructions += " [-output <summary/text>]"
+        instructions += " [-output <summary/text/badges>]"
         instructions += " [-repositoryURL <url>]"
         instructions += " [-sha <string>]"
         instructions += " [-debug true/false]"

--- a/Sources/xcodebuild-to-md/main.swift
+++ b/Sources/xcodebuild-to-md/main.swift
@@ -34,6 +34,8 @@ let testSummary = gatherTestSummary(from: resultKit)
 if let output = commandLine.output {
     if (output.lowercased() == "summary") {
         summaryOutput(findings: findings, testSummary: testSummary)
+    } else if (output.lowercased() == "badges" ) {
+        badgeOutput(findings: findings, testSummary: testSummary)
     } else {
         textOutput(findings: findings, testSummary: testSummary, includeWarnings: commandLine.includeWarnings)
     }


### PR DESCRIPTION
This PR adds a new `output` type called `badges`. In this mode, a summary will be generated that is just a list of badges using `shields.io`. This creates a more concise and easy to read list of summary output. To use just pass in `badges` instead of `summary`.

closes #9 
