### PR TITLE
Fix for xcresult files with less than 5 tests outputing slowest tests

### DIFF
--- a/Sources/xcodebuild-to-md/SlowestTestOutput.swift
+++ b/Sources/xcodebuild-to-md/SlowestTestOutput.swift
@@ -23,7 +23,7 @@ func slowestTestsOutput(
         return duration0 > duration1
     }
 
-    for test in testsSortedByDuration.prefix(upTo: slowTestCount) {
+    for test in testsSortedByDuration.prefix(upTo: min(slowTestCount, testsSortedByDuration.count)) {
         guard let duration = test.duration else { continue }
         print("|\(test.name ?? String("<no name test>"))|\(String(format: "%.02f", duration))|")
     }


### PR DESCRIPTION
`.prefix(unto:)` requires a number larger or equal to the number of the quantity of items in the array being sliced.